### PR TITLE
Add an universal identifier to tasks to help with data mining and evaluation

### DIFF
--- a/graphite/validator/forward.py
+++ b/graphite/validator/forward.py
@@ -84,7 +84,15 @@ async def forward(self):
     bt.logging.info(f"dataset ref {dataset_ref} selected from {list(self.loaded_datasets.keys())}" )
     selected_node_idxs = random.sample(range(len(self.loaded_datasets[dataset_ref]['data'])), n_nodes)
     task_uuid = str(uuid.uuid1())
-    test_problem_obj = GraphV2Problem(problem_type="Metric TSP", n_nodes=n_nodes, selected_ids=selected_node_idxs, cost_function="Geom", dataset_ref=dataset_ref, task_uuid=task_uuid)
+
+    test_problem_obj = GraphV2Problem(
+            problem_type="Metric TSP",
+            n_nodes=n_nodes,
+            selected_ids=selected_node_idxs,
+            cost_function="Geom",
+            dataset_ref=dataset_ref,
+            task_uuid=task_uuid
+    )
 
     try:
         graphsynapse_req = GraphV2Synapse(problem=test_problem_obj)

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -160,8 +160,11 @@ class Miner(BaseMinerNeuron):
         synapse.solution = route
         
         bt.logging.info(
-            f"Miner returned value {synapse.solution} {len(synapse.solution) if isinstance(synapse.solution, list) else synapse.solution}"
+            f"Miner completed task {synapse.problem.task_uuid} and returned value {synapse.solution} {len(synapse.solution) if isinstance(synapse.solution, list) else synapse.solution}"
         )
+
+        # TODO: Add logging to private WandB or optional public WandB
+        
         return synapse
 
     async def forwardV2(
@@ -189,7 +192,7 @@ class Miner(BaseMinerNeuron):
         #     f.write(log_line)
         
         bt.logging.info(
-            f"Miner received input to solve {synapse.problem.n_nodes}"
+            f"Miner received task {synapse.problem.task_uuid} to solve {synapse.problem.n_nodes}"
         )
 
         if isinstance(synapse.problem, GraphV2Problem):
@@ -208,8 +211,11 @@ class Miner(BaseMinerNeuron):
         synapse.problem.edges = None
         
         bt.logging.info(
-            f"Miner returned value {synapse.solution} {len(synapse.solution) if isinstance(synapse.solution, list) else synapse.solution}"
+            f"Miner completed task {synapse.problem.task_uuid} and returned value {synapse.solution} {len(synapse.solution) if isinstance(synapse.solution, list) else synapse.solution}"
         )
+
+        # TODO: Add logging to private WandB or optional public WandB
+        
         return synapse
     
     async def blacklist(


### PR DESCRIPTION
The task UUID is an unique identifier for each task given to miners by the validator. It allows miners and validators to identify the tasks, and allow for more detailed data mining and evaluation of performance.

The validator will assign a task_uuid to each request they send out, and the miner will be aware of this value. The miner can use this value to compare their output to the WandB dashboard and validator-produced logs or results. They can also use this value to self-evaluate based on personal logs or other means of output storage.