### PR TITLE
patching the USA_POI dataset

### DIFF
--- a/graphite/data/constants.py
+++ b/graphite/data/constants.py
@@ -3,4 +3,5 @@ ASIA_MSB_DETAILS = {"endpoint":"https://download.geofabrik.de/asia/malaysia-sing
 WORLD_TSP_DETAILS = {"endpoint":"https://www.math.uwaterloo.ca/tsp/world/world.tsp.gz",
                      "ref_id":"World_TSP"}
 USA_POI_DETAILS = {"endpoint":None,
-                   "ref_id":"USA_POI"}
+                   "ref_id":"USA_POI",
+                   "checksum":"b76546c0b9591c5df01a4b235e7c1377"}

--- a/graphite/data/dataset_utils.py
+++ b/graphite/data/dataset_utils.py
@@ -221,6 +221,12 @@ def check_and_get_usa_poi():
     fp = get_file_path(USA_POI_DETAILS['ref_id'])
     if fp.exists():
         # we have already downloaded and processed the data
+        # attempt to load and check against the checksum
+        usa_dataset = np.load(fp)
+        usa_dataset_checksum = usa_dataset['checksum']
+        if usa_dataset_checksum != USA_POI_DETAILS['checksum']:
+            bt.logging.info(f"Downloading {USA_POI_DETAILS['ref_id']} data from huggingface")
+            hf_hub_download(repo_id="Graphite-AI/coordinate_data", filename="USA_POI.npz", repo_type="dataset", local_dir=DATASET_DIR)
         bt.logging.info(f"{USA_POI_DETAILS['ref_id']} already downloaded")
         return
     else:


### PR DESCRIPTION
There was a ghost coordinate on index 64157 where the coordinate values were null. It has been patched with a pair of dummy values and the new dataset has been pushed to huggingface.

The following commit references the checksum of the new fixed dataset and compares it against the local copy. It then attempts to download it again if the checksums do not match. This overhead is only incurred on neuron start-up.